### PR TITLE
installgames.sh: Use new env var

### DIFF
--- a/installgames.sh
+++ b/installgames.sh
@@ -1,6 +1,11 @@
 #!/data/data/com.termux/files/usr/bin/env bash
 
 # ==========================================
+# Environment variables
+# ==========================================
+export SET_DIR="/storage/emulated/0/"
+
+# ==========================================
 # ANSI Colors
 # ==========================================
 BOLD="\033[1m"
@@ -161,7 +166,7 @@ if ! command -v depotdownloader >/dev/null 2>&1; then
     sleep 5
     echo -e "${BOLD}${GREEN}$LANG_INSTALLING${RESET} depotdownloader"
     sleep 3
-    curl -LO "https://raw.githubusercontent.com/source-br/Valve-on-android/main/Tools/installproot.sh"
+    curl -LO "https://raw.githubusercontent.com/TheKingFireS/TermuxDepotDownloader/alpine/installproot.sh"
     chmod +x installproot.sh
     ./installproot.sh
     echo -e "${BOLD}${GREEN}[*] depotdownloader $LANG_SUCCESS${RESET}"


### PR DESCRIPTION
I added environment variable named `SET_DIR`, this allow to change download to directory instead of static Download/depotdownloaded/. Tested it and worked since it downloaded to /storage/emulated/0/ now.

Since Tools folders is now unused, it's up to you to delete it or not.